### PR TITLE
feat(graphql): Use config options for all plugins

### DIFF
--- a/packages/graphql/src/build/builder-options.ts
+++ b/packages/graphql/src/build/builder-options.ts
@@ -11,4 +11,10 @@ export interface BuilderOptions {
   watch: boolean;
   /** Skip __typename in generated models */
   skipTypename?: boolean;
+  /** Make sure to generate code that compatible with TypeScript strict mode */
+  strict?: boolean;
+  /** Avoid using Pick and resolve the actual primitive type of all selection set */
+  preResolveTypes?: boolean;
+  /** Generates immutable types by adding readonly to properties and uses ReadonlyArray */
+  immutableTypes?: boolean;
 }

--- a/packages/graphql/src/build/generate-graphql-services.ts
+++ b/packages/graphql/src/build/generate-graphql-services.ts
@@ -32,7 +32,7 @@ async function graphQlCodeGenerator(
     outputPath,
     declarationFile,
     watch,
-    ...additionalConfig
+    ...config
   } = options;
   const modelsFolder = basename(outputPath);
 
@@ -43,12 +43,11 @@ async function graphQlCodeGenerator(
       documents,
       generates: {
         [join(outputPath, declarationFile)]: {
-          config: {
-            ...additionalConfig
-          },
+          config,
           plugins: ['typescript', 'fragment-matcher']
         },
         [join(outputPath)]: {
+          config,
           preset: 'near-operation-file',
           presetConfig: {
             baseTypesPath: declarationFile,

--- a/packages/graphql/src/build/generate-graphql-services.ts
+++ b/packages/graphql/src/build/generate-graphql-services.ts
@@ -1,5 +1,5 @@
 import { generate } from '@graphql-codegen/cli';
-import { readFileSync, writeFileSync } from 'fs';
+import { writeFileSync } from 'fs';
 import { join, basename } from 'path';
 import { BuilderOptions } from './builder-options';
 


### PR DESCRIPTION
I have started to ramp up development with a project using this library.
This is a small set of fixes I came across to make the library suit my needs.
There may be future PR if I need it to do more, but the main thing is expanding the support of the additional config options of my last PR. I work exclusively in `strict` mode in TypeScript so I need the `strict` option included for the TypeScript plugin of Codegen.